### PR TITLE
Add libs before starting the tomcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ Put your `*.jar` files (e.g. the WPS extension) in the `additional_libs` folder 
 
 `--build-arg ADDITIONAL_LIBS_PATH={RELATIVE_PATH_TO_YOUR_LIBS}`
 
+## How to add additional libs using an existing docker image?
+
+If you want to add geoserver extensions/libs by using a mount, you can add something like
+
+```
+--mount src="/dir/with/libs/on/host",target=/opt/additional_libs,type=bind
+```
+
+to your `docker run` command.
+
+**Note:** Do not change the target value!
+
 ## How to watch geoserver.log from host?
 
 `docker exec -it {CONTAINER_ID} tail -f /opt/geoserver_data/logs/geoserver.log`

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 
+ADDITIONAL_LIBS_DIR=/opt/additional_libs/
+
+# copy additional geoserver libs before starting the tomcat
+if [ -d "$ADDITIONAL_LIBS_DIR" ]; then
+    cp $ADDITIONAL_LIBS_DIR/*.jar $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
+fi
+
 # start the tomcat
 $CATALINA_HOME/bin/catalina.sh run


### PR DESCRIPTION
By adding something like

```
--mount src="/dir/with/libs/on/host",target=/opt/additional_libs,type=bind
```

to your `docker run` command you can easily add libs to a "fix" docker image. Note: The `target` value should not be changed.

Please review @hwbllmnn 