### PR TITLE
Add GDAL to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ WORKDIR /tmp
 RUN apk -U upgrade --update && \
     apk add curl && \
     apk add openssl && \
+    apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/main libressl2.7-libcrypto && \
+    apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing gdal && \
     rm -rf $CATALINA_HOME/webapps/*
 
 # install geoserver


### PR DESCRIPTION
This will add GDAL to the target system, which may be helpful if someone should install the importer extension (which requires GDAL)

Please review @hwbllmnn 