### PR TITLE
Release all versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use a minimal tomcat image as parent
-FROM terrestris/tomcat:latest
+FROM terrestris/tomcat:8.5.35
 
 # The GS_VERSION argument could be used like this to overwrite the default:
 # docker build --build-arg GS_VERSION=2.11.3 -t geoserver:2.11.3 .

--- a/util/gs-release-check.sh
+++ b/util/gs-release-check.sh
@@ -64,7 +64,7 @@ done
 if [[ -z "$LATEST_GS_VERSION" ]]; then
   echo "No new 'latest/stable' geoserver version available!"
 else
-  git checkout master #  > /dev/null 2>&1
+  git checkout master > /dev/null 2>&1
   sed -i "s;^ARG GS_VERSION=[0-9.]\+;ARG GS_VERSION=$LATEST_GS_VERSION;g" ../Dockerfile
   git commit --allow-empty -m "Update to latest version $LATEST_GS_VERSION" ../Dockerfile
   git push upstream master


### PR DESCRIPTION
This is an enhancement of the docker release script as this will release all versions >= v2.5 - even if a version lower than the latest has been released on maintenance in the meantime (e.g. v2.13.3. has been released after v2.14.0)

Also contains some smaller adjustments:

* an explicit tag for the parent tomcat docker image is now used (instead of latest)
* we will only process GS versions later than 2.4.8, i.e. starting with v2.5

@marcjansen @dnlkoch 