### PR TITLE
Install nss package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apk -U upgrade --update && \
     apk add curl && \
     apk add openssl && \
     apk add libressl2.7-libcrypto && \
+    apk add nss && \
     apk add zip && \
     apk add \
     --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \


### PR DESCRIPTION
This adds the `nss` package to fix the following error during the start of the container:

```
java.security.ProviderException: Could not initialize NSS
```

Please review @buehner.