### PR TITLE
Fixing issues with gdal and proj by switching base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,3 +74,9 @@ RUN curl -jkSL -o $CATALINA_HOME/lib/marlin.jar https://github.com/bourgesl/marl
 # cleanup
 RUN apt remove -y curl && \
     rm -rf /tmp/* /var/cache/apt/*
+
+COPY startup.sh /opt/startup.sh
+
+ENTRYPOINT /opt/startup.sh
+
+WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-# Use a minimal tomcat image as parent
-FROM terrestris/tomcat:8.5.37
+FROM tomcat:9-jdk8
 
 # The GS_VERSION argument could be used like this to overwrite the default:
 # docker build --build-arg GS_VERSION=2.11.3 -t geoserver:2.11.3 .
-ARG GS_VERSION=2.17.0
+ARG GS_VERSION=2.16.2
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/
 
@@ -21,16 +20,8 @@ ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS -Dfile.encoding=UTF-8 -D-XX:SoftRefLRUPolic
 WORKDIR /tmp
 
 # init
-RUN apk -U upgrade --update && \
-    apk add curl && \
-    apk add openssl && \
-    apk add libressl2.7-libcrypto && \
-    apk add nss && \
-    apk add zip && \
-    apk add \
-    --repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
-    --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
-    gdal && \
+RUN apt update && \
+    apt install -y curl openssl zip gdal-bin && \
     rm -rf $CATALINA_HOME/webapps/*
 
 # install geoserver
@@ -81,11 +72,5 @@ RUN curl -jkSL -o $CATALINA_HOME/lib/marlin.jar https://github.com/bourgesl/marl
     curl -jkSL -o $CATALINA_HOME/lib/marlin-sun-java2d.jar https://github.com/bourgesl/marlin-renderer/releases/download/v$MARLIN_TAG/marlin-$MARLIN_VERSION-Unsafe-sun-java2d.jar
 
 # cleanup
-RUN apk del curl && \
-    rm -rf /tmp/* /var/cache/apk/*
-
-COPY startup.sh /opt/startup.sh
-
-ENTRYPOINT /opt/startup.sh
-
-WORKDIR /opt
+RUN apt remove -y curl && \
+    rm -rf /tmp/* /var/cache/apt/*


### PR DESCRIPTION
In the past there have been issues when using the importer extension and importing raster data that
gdal was not able to find the proj library.
This issue could be tracked down to the usage of gdal from an unstable source.
This fix uses another base-image, which leads to a slight increase of the image size of about 20% but fixes the issue.
