### PR TITLE
Migrate docker build and push to github actions

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -1,9 +1,3 @@
-# https://github.com/marketplace/actions/build-and-push-docker-images
-# https://github.com/marketplace/actions/docker-metadata-action
-# type=ref,event=tag # on push tag, tag = 1.2.3
-# type=sha # tag = sha-ad132f5
-# latest=auto # takes care of tag latest
-
 name: Docker build and push
 
 on:
@@ -16,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: Checkout 🙂
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Create image and tag names
+      - name: Create image and tag names 😊
         id: meta
         uses: docker/metadata-action@v3
         with:
@@ -29,19 +23,19 @@ jobs:
             type=ref,event=branch
           flavor: |
             latest=auto
-      - name: Generate docker tag
+      - name: Generate docker tag 😝
         run: echo "docker_tag=$(echo ${{ steps.meta.outputs.tags }} | sed 's|^terrestris/geoserver:v|terrestris/geoserver:|')" >> $GITHUB_ENV
         id: generate-docker-tag
-      - name: Set up QEMU
+      - name: Set up QEMU 🤗
         uses: docker/setup-qemu-action@v1
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx 🤯
         uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
+      - name: Login to DockerHub 😎
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
-      - name: Build and push
+      - name: Build and push 🥳
         id: docker_build
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -41,13 +41,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
-      - name: Foo
-        run: echo ${{ env.docker_tag }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ env.docker_tag }}
+          tags: ${{ env.docker_tag }}, terrestris/geoserver:latest
           context: .
           file: Dockerfile

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -41,6 +41,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
+      - name: Foo
+        run: echo ${{ steps.generate-docker-tag.outputs.docker-tag }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -29,6 +29,9 @@ jobs:
             type=ref,event=branch
           flavor: |
             latest=auto
+      - name: Generate docker tag
+        run: echo '::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed 's/^v//')'
+        id: generate-docker-tag
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
@@ -40,11 +43,11 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
 #      - name: Build and push
 #        id: docker_build
-#        uses: docker/build-push-action@v2
+#        uses: docker/build-push-action@v5
 #        with:
 #          push: true
 #          tags: ${{ steps.meta.outputs.tags }}
 #          context: .
-#          file: docker/Dockerfile
+#          file: Dockerfile
       - name: Image digest
-        run: echo ${{ steps.meta.outputs.json }}
+        run: echo ${{ steps.generate-docker-tag.outputs.docker-tag }}

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -30,7 +30,7 @@ jobs:
           flavor: |
             latest=auto
       - name: Generate docker tag
-        run: echo '::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed 's/^terrestris\/geoserver:v/terrestris\/geoserver:/')'
+        run: echo '::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed 's|^terrestris/geoserver:v|terrestris/geoserver:|')'
         id: generate-docker-tag
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -1,0 +1,51 @@
+# https://github.com/marketplace/actions/build-and-push-docker-images
+# https://github.com/marketplace/actions/docker-metadata-action
+# type=ref,event=tag # on push tag, tag = 1.2.3
+# type=sha # tag = sha-ad132f5
+# latest=auto # takes care of tag latest
+
+name: Docker build and push
+
+on:
+  push:
+    branches: ['nb.test']
+
+jobs:
+  docker:
+    name: docker build and push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Create image and tag names
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: terrestris/geoserver
+          tags: |
+            type=ref,event=branch
+            type=sha
+          flavor: |
+            latest=auto
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN  }}
+#      - name: Build and push
+#        id: docker_build
+#        uses: docker/build-push-action@v2
+#        with:
+#          push: true
+#          tags: ${{ steps.meta.outputs.tags }}
+#          context: .
+#          file: docker/Dockerfile
+      - name: Image digest
+        run: echo ${{ steps.meta.outputs.json }}

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -41,13 +41,11 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
-#      - name: Build and push
-#        id: docker_build
-#        uses: docker/build-push-action@v5
-#        with:
-#          push: true
-#          tags: ${{ steps.meta.outputs.tags }}
-#          context: .
-#          file: Dockerfile
-      - name: Image digest
-        run: echo ${{ steps.generate-docker-tag.outputs.docker-tag }}
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: ${{ steps.generate-docker-tag.outputs.docker-tag }}
+          context: .
+          file: Dockerfile

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -30,7 +30,7 @@ jobs:
           flavor: |
             latest=auto
       - name: Generate docker tag
-        run: echo '::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed "s|^terrestris/geoserver:v|terrestris/geoserver:|")'
+        run: echo "::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed \"s|^terrestris/geoserver:v|terrestris/geoserver:|\")"
         id: generate-docker-tag
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -8,7 +8,7 @@ name: Docker build and push
 
 on:
   push:
-    branches: ['nb.test']
+    branches: ['v*.*.*']
 
 jobs:
   docker:
@@ -27,18 +27,17 @@ jobs:
           images: terrestris/geoserver
           tags: |
             type=ref,event=branch
-            type=sha
           flavor: |
             latest=auto
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN  }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN  }}
 #      - name: Build and push
 #        id: docker_build
 #        uses: docker/build-push-action@v2

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -30,7 +30,7 @@ jobs:
           flavor: |
             latest=auto
       - name: Generate docker tag
-        run: echo '::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed 's|^terrestris/geoserver:v|terrestris/geoserver:|')'
+        run: echo '::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed "s|^terrestris/geoserver:v|terrestris/geoserver:|")'
         id: generate-docker-tag
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -30,7 +30,7 @@ jobs:
           flavor: |
             latest=auto
       - name: Generate docker tag
-        run: echo "::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed \"s|^terrestris/geoserver:v|terrestris/geoserver:|\")"
+        run: echo "docker_tag=$(echo ${{ steps.meta.outputs.tags }} | sed 's|^terrestris/geoserver:v|terrestris/geoserver:|')" >> $GITHUB_ENV
         id: generate-docker-tag
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -42,12 +42,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
       - name: Foo
-        run: echo ${{ steps.generate-docker-tag.outputs.docker-tag }}
+        run: echo ${{ env.docker_tag }}
       - name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ steps.generate-docker-tag.outputs.docker-tag }}
+          tags: ${{ env.docker_tag }}
           context: .
           file: Dockerfile

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -30,7 +30,7 @@ jobs:
           flavor: |
             latest=auto
       - name: Generate docker tag
-        run: echo '::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed 's/^v//')'
+        run: echo '::set-output name=docker-tag::$(echo ${{ steps.meta.outputs.tags }} | sed 's/^terrestris\/geoserver:v/terrestris\/geoserver:/')'
         id: generate-docker-tag
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -43,7 +43,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN  }}
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v2
         with:
           push: true
           tags: ${{ steps.generate-docker-tag.outputs.docker-tag }}


### PR DESCRIPTION
As docker hub does not provide free building anymore, we can now use the github action workflows for that.