### PR TITLE
Migrate docker build to github actions

### DIFF
--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -21,8 +21,6 @@ jobs:
           images: terrestris/geoserver
           tags: |
             type=ref,event=branch
-          flavor: |
-            latest=auto
       - name: Generate docker tag 😝
         run: echo "docker_tag=$(echo ${{ steps.meta.outputs.tags }} | sed 's|^terrestris/geoserver:v|terrestris/geoserver:|')" >> $GITHUB_ENV
         id: generate-docker-tag

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -1,0 +1,45 @@
+name: Docker build and push
+
+on:
+  push:
+    branches: ['v*.*.*']
+
+jobs:
+  docker:
+    name: docker build and push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🙂
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Create image and tag names 😊
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: terrestris/geoserver
+          tags: |
+            type=ref,event=branch
+          flavor: |
+            latest=auto
+      - name: Generate docker tag 😝
+        run: echo "docker_tag=$(echo ${{ steps.meta.outputs.tags }} | sed 's|^terrestris/geoserver:v|terrestris/geoserver:|')" >> $GITHUB_ENV
+        id: generate-docker-tag
+      - name: Set up QEMU 🤗
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx 🤯
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub 😎
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN  }}
+      - name: Build and push 🥳
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ env.docker_tag }}, terrestris/geoserver:latest
+          context: .
+          file: Dockerfile


### PR DESCRIPTION
As docker hub does not provide free docker image builds anymore, we now use the github action worfklows for this.