### PR TITLE
Add geostyler plugin to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,8 @@ RUN cd .. && rm -rf tmp_extract
 
 WORKDIR /tmp
 
+RUN curl -jkSL -o ${GEOSERVER_LIB_DIR}gs-geostyler-${GEOSERVER_VERSION}.jar https://repo.osgeo.org/repository/Geoserver-releases/org/geoserver/community/gs-geostyler/$GEOSERVER_VERSION/gs-geostyler-$GEOSERVER_VERSION.jar
+
 COPY $GS_DATA_PATH $GEOSERVER_DATA_DIR
 COPY $ADDITIONAL_LIBS_PATH $GEOSERVER_LIB_DIR
 


### PR DESCRIPTION
As suggested in https://github.com/terrestris/docker-geoserver/issues/20, this will build the geostyler plugin into the resulting docker image.