### PR TITLE
feature: Add custom fonts (e.g. for SLD styling)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM tomcat:9-jdk11
 ARG GS_VERSION=2.19.2
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/
+ARG ADDITIONAL_FONTS_PATH=./additional_fonts/
 
 # Environment variables
 ENV GEOSERVER_VERSION=$GS_VERSION
@@ -53,6 +54,7 @@ RUN curl -jkSL -o ${GEOSERVER_LIB_DIR}gs-geostyler-${GEOSERVER_VERSION}.jar http
 
 COPY $GS_DATA_PATH $GEOSERVER_DATA_DIR
 COPY $ADDITIONAL_LIBS_PATH $GEOSERVER_LIB_DIR
+COPY $ADDITIONAL_FONTS_PATH /usr/share/fonts/truetype/
 
 # install java advanced imaging
 RUN wget https://download.java.net/media/jai/builds/release/1_1_3/jai-1_1_3-lib-linux-amd64.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ If you want to add geoserver extensions/libs by using a mount, you can add somet
 --mount src="/dir/with/libs/on/host",target=/opt/additional_libs,type=bind
 ```
 
+## How to add additional fonts to the docker image (e.g. for SLD styling)?
+
+If you want to add custom fonts (the base image only contains 26 fonts) by using a mount, you can add something like
+
+```
+--mount src="/dir/with/fonts/on/host",target=/opt/additional_fonts,type=bind
+```
+
 to your `docker run` command.
 
 **Note:** Do not change the target value!

--- a/additional_fonts/.gitignore
+++ b/additional_fonts/.gitignore
@@ -1,0 +1,5 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore
+

--- a/startup.sh
+++ b/startup.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
 
 ADDITIONAL_LIBS_DIR=/opt/additional_libs/
+ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
 
 # copy additional geoserver libs before starting the tomcat
 if [ -d "$ADDITIONAL_LIBS_DIR" ]; then
     cp $ADDITIONAL_LIBS_DIR/*.jar $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
+fi
+
+# copy additional fonts before starting the tomcat
+if [ -d "$ADDITIONAL_FONTS_DIR" ]; then
+    cp $ADDITIONAL_FONTS_DIR/*.ttf /usr/share/fonts/truetype/
 fi
 
 # start the tomcat


### PR DESCRIPTION
This adds the new feature to add custom fonts (*.ttf files)

By default, the base image only provides 26 fonts. This may not be sufficient if you need custom fonts for SLD styling.

This PR enables the possibility to add custom fonts via a mounted directory.