### PR TITLE
Add docker-compose demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ to your `docker run` command.
 ## How to watch geoserver.log from host?
 
 `docker exec -it {CONTAINER_ID} tail -f /opt/geoserver_data/logs/geoserver.log`
+
+## How to use the docker-compose demo?
+
+`docker-compose -f docker-compose-demo.yml up --build`

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -1,0 +1,14 @@
+version: '3'
+services:
+  geoserver:
+    build:
+      context: .
+      args:
+        - GS_VERSION=2.19.2
+    ports:
+      - 8080:8080
+    environment:
+      - EXTRA_JAVA_OPTS=-Xms512m -Xmx1g
+    volumes:
+      - ./additional_libs:/opt/additional_libs:Z # by mounting this we can install libs from host on startup
+      - ./additional_fonts:/opt/additional_fonts:Z # by mounting this we can install fonts from host on startup


### PR DESCRIPTION
This adds a simple docker-compose demo to demonstrate the possibilities of the docker image.
The demo is using the `context` feature and the local `Dockerfile`, but in case you are using a pre-built image from dockerhub, all features of the `environment` and `volumes` are available (e.g. using custom java opts or adding custom libs and fonts)

This will pretty sure be extended with upcoming features i am planning to implement