### PR TITLE
Add CORS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ ARG GS_VERSION=2.19.2
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/
 ARG ADDITIONAL_FONTS_PATH=./additional_fonts/
+ARG CORS_ENABLED=false
+ARG CORS_ALLOWED_ORIGINS=*
+ARG CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS
+ARG CORS_ALLOWED_HEADERS=*
 
 # Environment variables
 ENV GEOSERVER_VERSION=$GS_VERSION
@@ -14,6 +18,10 @@ ENV MARLIN_VERSION=0.9.4.3
 ENV GEOSERVER_DATA_DIR=/opt/geoserver_data/
 ENV GEOSERVER_LIB_DIR=$CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
 ENV EXTRA_JAVA_OPTS="-Xms256m -Xmx1g"
+ENV CORS_ENABLED=$CORS_ENABLED
+ENV CORS_ALLOWED_ORIGINS=$CORS_ALLOWED_ORIGINS
+ENV CORS_ALLOWED_METHODS=$CORS_ALLOWED_METHODS
+ENV CORS_ALLOWED_HEADERS=$CORS_ALLOWED_HEADERS
 
 # see http://docs.geoserver.org/stable/en/user/production/container.html
 ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS -Dfile.encoding=UTF-8 -D-XX:SoftRefLRUPolicyMSPerMB=36000 -Xbootclasspath/a:$CATALINA_HOME/lib/marlin.jar -Xbootclasspath/a:$CATALINA_HOME/lib/marlin-sun-java2d.jar -Dsun.java2d.renderer=org.marlin.pisces.PiscesRenderingEngine -Dorg.geotools.coverage.jaiext.enabled=true"

--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 
 This Dockerfile can be used to create images for all geoserver versions since 2.5.
 
-Based on [tomcat:9-jdk11](https://hub.docker.com/_/tomcat):
+Based on [tomcat:9-jre11-openjdk-slim](https://hub.docker.com/_/tomcat):
 
 * Debian based Linux
-* OpenJDK 11 (since October 2021)
+* OpenJDK 11
 * Tomcat 9
 * GeoServer
   * Native Java advanced imaging (JAI) is installed
-  * (but) [JAI-EXT](http://docs.geoserver.org/stable/en/user/configuration/image_processing/index.html#jai-ext) is enabled by default
+  * [JAI-EXT](http://docs.geoserver.org/stable/en/user/configuration/image_processing/index.html#jai-ext) is enabled by default
   * Marlin renderer
+  * Support of custom fonts (e.g. for SLD styling)
+  * [GeoStyler](https://www.osgeo.org/projects/geostyler/) included
+  * CORS support
 
 **IMPORTANT NOTE:** Please change the default geoserver master password! The default masterpw is located in this file (within the docker container): `/opt/geoserver_data/security/masterpw/default/masterpw`
 

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -9,6 +9,10 @@ services:
       - 8080:8080
     environment:
       - EXTRA_JAVA_OPTS=-Xms512m -Xmx1g
+      - CORS_ENABLED=true
+      - CORS_ALLOWED_ORIGINS=*
+      - CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS
+      - CORS_ALLOWED_HEADERS=*
     volumes:
       - ./additional_libs:/opt/additional_libs:Z # by mounting this we can install libs from host on startup
       - ./additional_fonts:/opt/additional_fonts:Z # by mounting this we can install fonts from host on startup

--- a/startup.sh
+++ b/startup.sh
@@ -13,5 +13,32 @@ if [ -d "$ADDITIONAL_FONTS_DIR" ]; then
     cp $ADDITIONAL_FONTS_DIR/*.ttf /usr/share/fonts/truetype/
 fi
 
+# configure CORS (inspired by https://github.com/oscarfonts/docker-geoserver)
+# if enabled, this will add the filter definitions
+# to the end of the web.xml
+if [ "${CORS_ENABLED}" = "true" ]; then
+    sed -i "\:</web-app>:i\\
+    <filter>\n\
+      <filter-name>CorsFilter</filter-name>\n\
+      <filter-class>org.apache.catalina.filters.CorsFilter</filter-class>\n\
+      <init-param>\n\
+          <param-name>cors.allowed.origins</param-name>\n\
+          <param-value>${CORS_ALLOWED_ORIGINS}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+          <param-name>cors.allowed.methods</param-name>\n\
+          <param-value>${CORS_ALLOWED_METHODS}</param-value>\n\
+      </init-param>\n\
+      <init-param>\n\
+        <param-name>cors.allowed.headers</param-name>\n\
+        <param-value>${CORS_ALLOWED_HEADERS}</param-value>\n\
+      </init-param>\n\
+    </filter>\n\
+    <filter-mapping>\n\
+      <filter-name>CorsFilter</filter-name>\n\
+      <url-pattern>/*</url-pattern>\n\
+    </filter-mapping>" "$CATALINA_HOME/webapps/geoserver/WEB-INF/web.xml";
+fi
+
 # start the tomcat
 $CATALINA_HOME/bin/catalina.sh run


### PR DESCRIPTION
This PR enables (optional) CORS support.

In most scenarios you will probably configure CORS on a proxy level, but in case you want to enable CORS in the geoserver directly, this can be done easily now by setting the new environment variable `CORS_ENABLED` to `true`. In that case, the `startup.sh` script will add the necessary filter definitions to the `web.xml`.

Origins, methods and headers can (optionally) be configured with these new environment values:

* `CORS_ALLOWED_ORIGINS` (default: `*`)
* `CORS_ALLOWED_METHODS` (default: `GET,POST,PUT,DELETE,HEAD,OPTIONS`)
* `CORS_ALLOWED_HEADERS` (default: `*`)

By default, CORS is **not** enabled!