### PR TITLE
Refactor CATALINA_OPTS definition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,16 @@ ENV CORS_ALLOWED_METHODS=$CORS_ALLOWED_METHODS
 ENV CORS_ALLOWED_HEADERS=$CORS_ALLOWED_HEADERS
 
 # see http://docs.geoserver.org/stable/en/user/production/container.html
-ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS -Dfile.encoding=UTF-8 -D-XX:SoftRefLRUPolicyMSPerMB=36000 -Xbootclasspath/a:$CATALINA_HOME/lib/marlin.jar -Xbootclasspath/a:$CATALINA_HOME/lib/marlin-sun-java2d.jar -Dsun.java2d.renderer=org.marlin.pisces.PiscesRenderingEngine -Dorg.geotools.coverage.jaiext.enabled=true"
+ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
+    -Djava.awt.headless=true -server \
+    -Dfile.encoding=UTF-8 \
+    -Djavax.servlet.request.encoding=UTF-8 \
+    -Djavax.servlet.response.encoding=UTF-8 \
+    -D-XX:SoftRefLRUPolicyMSPerMB=36000 \
+    -Xbootclasspath/a:$CATALINA_HOME/lib/marlin.jar \
+    -Xbootclasspath/a:$CATALINA_HOME/lib/marlin-sun-java2d.jar \
+    -Dsun.java2d.renderer=org.marlin.pisces.PiscesRenderingEngine \
+    -Dorg.geotools.coverage.jaiext.enabled=true"
 
 WORKDIR /tmp
 


### PR DESCRIPTION
Just a minor change: Refactoring the definition of CATALINA_OPTS to make it more readable.

Also added these new values:

* -Djava.awt.headless=true -server
* -Djavax.servlet.request.encoding=UTF-8
* -Djavax.servlet.response.encoding=UTF-8