### PR TITLE
feature: Download configured extensions on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ARG CORS_ENABLED=false
 ARG CORS_ALLOWED_ORIGINS=*
 ARG CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS
 ARG CORS_ALLOWED_HEADERS=*
+ARG STABLE_PLUGIN_URL=https://sourceforge.net/projects/geoserver/files/GeoServer/${GS_VERSION}/extensions
 
 # Environment variables
 ENV GEOSERVER_VERSION=$GS_VERSION
@@ -22,6 +23,12 @@ ENV CORS_ENABLED=$CORS_ENABLED
 ENV CORS_ALLOWED_ORIGINS=$CORS_ALLOWED_ORIGINS
 ENV CORS_ALLOWED_METHODS=$CORS_ALLOWED_METHODS
 ENV CORS_ALLOWED_HEADERS=$CORS_ALLOWED_HEADERS
+ENV DEBIAN_FRONTEND=noninteractive
+ENV INSTALL_EXTENSIONS=false
+ENV STABLE_EXTENSIONS=''
+ENV STABLE_PLUGIN_URL=$STABLE_PLUGIN_URL
+ENV ADDITIONAL_LIBS_DIR=/opt/additional_libs/
+ENV ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
 
 # see http://docs.geoserver.org/stable/en/user/production/container.html
 ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
@@ -93,10 +100,11 @@ RUN curl -jkSL -o $CATALINA_HOME/lib/marlin.jar https://github.com/bourgesl/marl
     curl -jkSL -o $CATALINA_HOME/lib/marlin-sun-java2d.jar https://github.com/bourgesl/marlin-renderer/releases/download/v$MARLIN_TAG/marlin-$MARLIN_VERSION-Unsafe-sun-java2d.jar
 
 # cleanup
-RUN apt remove -y curl && \
-    rm -rf /tmp/* /var/cache/apt/*
+RUN rm -rf /tmp/* /var/cache/apt/*
 
-COPY startup.sh /opt/startup.sh
+# copy scripts
+COPY *.sh /opt/
+RUN chmod +x /opt/*.sh
 
 ENTRYPOINT /opt/startup.sh
 

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -9,6 +9,8 @@ services:
       - 8080:8080
     environment:
       - EXTRA_JAVA_OPTS=-Xms512m -Xmx1g
+      - INSTALL_EXTENSIONS=true
+      - STABLE_EXTENSIONS=wps,csw # this will install wps and csw extensions on startup
       - CORS_ENABLED=true
       - CORS_ALLOWED_ORIGINS=*
       - CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS

--- a/install-extensions.sh
+++ b/install-extensions.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Inspired by https://github.com/kartoza/docker-geoserver
+
+function download_extension() {
+  URL=$1
+  EXTENSION=$2
+  DOWNLOAD_FILE="${ADDITIONAL_LIBS_DIR}geoserver-${GEOSERVER_VERSION}-${EXTENSION}-plugin.zip"
+
+  if [ -e "$DOWNLOAD_FILE" ]; then
+      echo "$DOWNLOAD_FILE already exists. Skipping download."
+  else
+    if curl --output /dev/null --silent --head --fail "${URL}"; then
+        echo -e "\nDownloading ${EXTENSION}-extension from ${URL} to ${DOWNLOAD_FILE}"
+        wget --progress=bar:force:noscroll -c --no-check-certificate "${URL}" -O ${DOWNLOAD_FILE}
+      else
+        echo "URL does not exist: ${URL}"
+    fi
+  fi
+}
+
+# Download stable plugins only if INSTALL_EXTENSIONS is true
+if [ "$INSTALL_EXTENSIONS" = "true" ]; then
+  echo "Starting download of extensions"
+  for EXTENSION in $(echo "${STABLE_EXTENSIONS}" | tr ',' ' '); do
+    URL="${STABLE_PLUGIN_URL}/geoserver-${GEOSERVER_VERSION}-${EXTENSION}-plugin.zip"
+    download_extension ${URL} ${EXTENSION}
+  done
+  echo "Finished download of extensions"
+fi
+
+# Install all extensions that are available in the additional lib dir now
+echo "Starting installation of extensions"
+for ADDITIONAL_LIB in ${ADDITIONAL_LIBS_DIR}*; do
+  [ -e "$ADDITIONAL_LIB" ] || continue
+
+  if [[ $ADDITIONAL_LIB == *.zip ]]; then
+    unzip -q -o -d ${GEOSERVER_LIB_DIR} ${ADDITIONAL_LIB} "*.jar"
+    echo "Installed all jar files from ${ADDITIONAL_LIB}"
+  elif [[ $ADDITIONAL_LIB == *.jar ]]; then
+    cp ${ADDITIONAL_LIB} ${GEOSERVER_LIB_DIR}
+    echo "Installed ${ADDITIONAL_LIB}"
+  else
+    echo "Skipping ${ADDITIONAL_LIB}: unknown file extension."
+  fi
+done
+echo "Finished installation of extensions"

--- a/startup.sh
+++ b/startup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-ADDITIONAL_LIBS_DIR=/opt/additional_libs/
-ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
+## install GeoServer extensions before starting the tomcat
+/opt/install-extensions.sh
 
 # copy additional geoserver libs before starting the tomcat
 if [ -d "$ADDITIONAL_LIBS_DIR" ]; then


### PR DESCRIPTION
This introduces a new feature:

By setting the new `INSTALL_EXTENSIONS` environment variable to `true` and configuring a comma separated list of extensions in the new env `STABLE_EXTENSIONS`, the startup script will download and install these extensions before starting the tomcat.

Probably you do not want to use this feature in production, but for quick or dev setups, this can be very helpful as you do not have to care about all of your extensions in the correct version, but can simply configure them.

See docker compose demo