### PR TITLE
Prepare for grass raster datastore

### DIFF
--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - 8080:8080
     environment:
-      - EXTRA_JAVA_OPTS=-Xms512m -Xmx1g
+      - EXTRA_JAVA_OPTS=-Xms512m -Xmx1g -Djava.libary.path=/usr/lib/jni/:/usr/lib/grass78/lib/
       - INSTALL_EXTENSIONS=true
       - STABLE_EXTENSIONS=wps,csw # this will install wps and csw extensions on startup
       - CORS_ENABLED=true
@@ -18,3 +18,4 @@ services:
     volumes:
       - ./additional_libs:/opt/additional_libs:Z # by mounting this we can install libs from host on startup
       - ./additional_fonts:/opt/additional_fonts:Z # by mounting this we can install fonts from host on startup
+      - ./geoserver_data/:/opt/geoserver_data:Z


### PR DESCRIPTION
With these changes simply adding the GeoServer grass raster datastore jar and the `gdal.jar` is sufficient to get GRASS support.

Switches to ubuntu 22.04 as base image as the debian gdal-grass driver does currently not work even when compiled from source.

Please review @terrestris/devs 