### PR TITLE
Update tomcat to version 9.0.62

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # The GS_VERSION argument could be used like this to overwrite the default:
 # docker build --build-arg GS_VERSION=2.11.3 -t geoserver:2.11.3 .
-ARG TOMCAT_VERSION=9.0.60
+ARG TOMCAT_VERSION=9.0.62
 ARG GS_VERSION=2.20.3
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/


### PR DESCRIPTION
Title says it all.

Required due to https://spring.io/blog/2022/04/01/spring-framework-rce-mitigation-alternative

Plz review @terrestris/devs 