### PR TITLE
Check for geostyler compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,8 +102,7 @@ RUN zip -qr9 ../gs-web-core-${GEOSERVER_VERSION}.jar *
 RUN cd .. && rm -rf tmp_extract
 
 WORKDIR /tmp
-
-RUN wget -q -O ${GEOSERVER_LIB_DIR}gs-geostyler-${GEOSERVER_VERSION}.jar https://repo.osgeo.org/repository/Geoserver-releases/org/geoserver/community/gs-geostyler/$GEOSERVER_VERSION/gs-geostyler-$GEOSERVER_VERSION.jar
+RUN echo ${GEOSERVER_VERSION} > /tmp/version.txt; echo "2.15.5" >> /tmp/version.txt; if(test $(sort -V /tmp/version.txt|head -n 1) != "2.15.5"); then echo "Skipping installation of geostyler due to version incompatibility."; else wget -q -O ${GEOSERVER_LIB_DIR}gs-geostyler-${GEOSERVER_VERSION}.jar https://repo.osgeo.org/repository/Geoserver-releases/org/geoserver/community/gs-geostyler/$GEOSERVER_VERSION/gs-geostyler-$GEOSERVER_VERSION.jar; fi
 
 COPY $GS_DATA_PATH $GEOSERVER_DATA_DIR
 COPY $ADDITIONAL_LIBS_PATH $GEOSERVER_LIB_DIR


### PR DESCRIPTION
In case you want to build older versions (< 2.16.0), geostyler extension is not available, so we need this check to ensure that build is still working