### PR TITLE
Install curl required in script for extension install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
 
 # init
 RUN apt update && apt -y upgrade && \
-    apt install -y openssl zip gdal-bin wget openjdk-11-jdk grass-dev libpq-dev make g++ checkinstall && \
+    apt install -y openssl zip gdal-bin wget curl openjdk-11-jdk grass-dev libpq-dev make g++ checkinstall && \
     rm -rf $CATALINA_HOME/webapps/*
 
 RUN wget -q https://nexus.terrestris.de/repository/raw-public/debian/libgdal-java_1.0_all.deb


### PR DESCRIPTION
Title says it all.

Since `curl` is used in [install-extensions.sh](https://github.com/terrestris/docker-geoserver/blob/master/install-extensions.sh) it has to be installed.

Plz review @terrestris/devs 