### PR TITLE
Install maven and git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,7 @@ COPY --from=builder /tmp/gdal-grass-${GDAL_GRASS_VERSION}/gdal-grass_${GDAL_GRAS
 # init
 RUN apt update && \
     apt -y upgrade && \
-    apt install -y --no-install-recommends openssl zip unzip gdal-bin wget curl openjdk-11-jdk \
+    apt install -y --no-install-recommends openssl zip unzip gdal-bin wget curl openjdk-11-jdk git maven \
     libbz2-dev libglfw3-dev libgl1-mesa-dev libglu1-mesa-dev libfftw3-dev fakeroot libjs-jquery \
     libcairo2-dev libgdal-dev libzstd-dev libpq-dev libproj-dev python3-numpy \
     python3-pil python3-ply python3-six && \


### PR DESCRIPTION
Whenever a GeoStyler community plugin JAR is not available at https://repo.osgeo.org/#browse/browse:Geoserver-releases:org%2Fgeoserver%2Fcommunity%2Fgs-geostyler the Dockerfile will build the JAR itself based on the sources. Due to some refactoring, git and maven were not available, so these dependencies should be installed

This occured only for the 2.20.4 until now and could be fixed like this: https://github.com/terrestris/docker-geoserver/commit/eca97b2cd53d2515ec86fc420bbfbcff45281f06

So this should also be merge in master to enhance future stability