### PR TITLE
fix: do not uninstall requried packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -245,7 +245,7 @@ RUN wget -q -O $CATALINA_HOME/lib/marlin.jar https://github.com/bourgesl/marlin-
     wget -q -O $CATALINA_HOME/lib/marlin-sun-java2d.jar https://github.com/bourgesl/marlin-renderer/releases/download/v$(echo "$MARLIN_VERSION" | sed "s/\./_/g")/marlin-$MARLIN_VERSION-Unsafe-sun-java2d.jar
 
 # cleanup
-RUN apt purge -y zip unzip wget curl && \
+RUN apt purge -y && \
     apt autoremove --purge -y && \
     rm -rf /tmp/*
 


### PR DESCRIPTION
Removes the uninstall of `zip`, `unzip`, `wget` and `curl` because these are required to run [install-extensions.sh](https://github.com/terrestris/docker-geoserver/blob/master/install-extensions.sh) during runtime.

@terrestris/devs Please review